### PR TITLE
#4 Prevent pageview event triggering twice on landing

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -26,12 +26,11 @@ exports.onRenderBody = ({ setHeadComponents, setPostBodyComponents }, pluginOpti
     );
     window.GATSBY_GTAG_PLUGIN_ANONYMIZE = ${anonymize};
 
-    let options = undefined;
-
+    let options = {
+      send_page_view: false
+    };
     if (${anonymize}) {
-      options = {
-        anonymize_ip: true
-      };
+      options.anonymize_ip = true;
     }
 
     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
This caused misleading statistics.