### PR TITLE
Use var instead of let

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -29,7 +29,7 @@ exports.onRenderBody = (
     );
     window.GATSBY_GTAG_PLUGIN_ANONYMIZE = ${anonymize};
 
-    let options = {
+    var options = {
       send_page_view: false
     };
     if (${anonymize}) {


### PR DESCRIPTION
Fixes Google Search Console error -- "Block-scoped declarations are not yet supported outside of strict mode"