### PR TITLE
Add Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+import * as React from "react"
+
+interface OutboundLinkProps {
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
+}
+
+export class OutboundLink extends React.Component<
+  OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>,
+  any
+> 


### PR DESCRIPTION
Copied from https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-google-analytics/index.d.ts

---

 Adding this file to my `node_modules/gatsby-plugin-gtag` stops typescript complaining when I import gatsby-plugin-gtag. The error

```
error TS7016: Could not find a declaration file for module 'gatsby-plugin-gtag'. '/Users/benscott/src/github.com/Shopify/polaris-icons/node_modules/gatsby-plugin-gtag/index.js' implicitly has an 'any' type.
  Try `npm install @types/gatsby-plugin-gtag` if it exists or add a new declaration (.d.ts) file containing `declare module 'gatsby-plugin-gtag';`

14 import {OutboundLink} from 'gatsby-plugin-gtag';
```

is now removed.