### PR TITLE
Allow gtag to be enabled in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Puts tracking script in the head instead of the body. Default is false (render i
 Adds `anonymize_ip` flag when calling `gtag`. More info
 [here](https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization).
 
+## Testing in development mode
+
+By default `gatsby-plugin-gtag` will only load and run google analytics when `process.env.NODE_ENV === 'production'`.
+To enable gtag in development mode set the environment variable `GATSBY_GTAG_DEBUG=true gatsby develop`.
+
 ## License
 
 MIT

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -7,8 +7,9 @@ exports.onRenderBody = (
   pluginOptions
 ) => {
   if (
-    process.env.NODE_ENV !== 'production' ||
-    !pluginOptions.trackingId
+    !pluginOptions.trackingId ||
+    (process.env.GATSBY_GTAG_DEBUG !== 'true' &&
+      process.env.NODE_ENV !== 'production')
   ) {
     return null;
   }


### PR DESCRIPTION
This option is useful for when you are trying to test custom gtag events or funnels not on a production site.

I'm trying to test my gtag setup options and some funnels/conversions on my local machine with a staging Analytics ID. This allows me to bypass the hardcoded production requirement.